### PR TITLE
update max_input_vars to 1500

### DIFF
--- a/docker/build/assets/usr/local/etc/php/conf.d/php.ini
+++ b/docker/build/assets/usr/local/etc/php/conf.d/php.ini
@@ -383,7 +383,7 @@ max_input_time = 60
 ;max_input_nesting_level = 64
 
 ; How many GET/POST/COOKIE input variables may be accepted
-; max_input_vars = 1000
+max_input_vars = 1500
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit


### PR DESCRIPTION
Relevant for Craft CMS projects with large matrix fields