### PR TITLE
Mitigate CVE-2024-2961 vulnerability by removing charset

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -115,6 +115,11 @@ RUN apt-get --no-install-recommends install -y \
     docker-php-ext-install opcache && \
     docker-php-ext-enable opcache
 
+# Remove ISO-2022-CN-EXT Charset (CVE-2024-2961)
+RUN sed -i '/ISO-2022-CN-EXT/s/^/#/' /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.d/gconv-modules-extra.conf && \
+    iconvconfig && \
+    iconv -l | grep -E 'CN-?EXT' && exit 1 || true
+
 # Set time zone
 RUN rm /etc/localtime && \
     ln -s /usr/share/zoneinfo/${TIMEZONE} /etc/localtime && \


### PR DESCRIPTION
tests performed: docker build . before and after the change and running iconv -l | grep -E 'CN-?EXT' in the container before and after.

Before change outputs are:
ISO-2022-CN-EXT//
ISO2022CNEXT//

After change outputs are:
--empty line--