### PR TITLE
Feature/php fpm 8.3 imagick workaround

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -109,8 +109,13 @@ RUN apt-get --no-install-recommends install -y \
     docker-php-ext-install exif && \
     docker-php-ext-install zip && \
     \
-    pecl install imagick && \
-    docker-php-ext-enable imagick && \
+    # imagick 3.7.0 contains a bug that prevents the pecl install on arm64
+    # leverage https://github.com/mlocati/docker-php-extension-installer to install imagick from the commit that contains the fix \
+    # can be removed as soon as imagick releases a new version and replaced with the old version
+    ( curl -sSLf https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - || echo 'return 1' ) | sh -s \
+          imagick/imagick@9df92616f577e38625b96b7b903582a46c064739 && \
+#    pecl install imagick && \
+#    docker-php-ext-enable imagick && \
     \
     docker-php-ext-install opcache && \
     docker-php-ext-enable opcache

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -110,8 +110,8 @@ RUN apt-get --no-install-recommends install -y \
     docker-php-ext-install zip && \
     \
     # imagick 3.7.0 contains a bug that prevents the pecl install on arm64
-    # leverage https://github.com/mlocati/docker-php-extension-installer to install imagick from the commit that contains the fix \
-    # can be removed as soon as imagick releases a new version and replaced with the old version
+    # leverage https://github.com/mlocati/docker-php-extension-installer to install imagick from the commit that contains the fix
+    # can be removed as soon as imagick releases a new version, switch to regular pecl install afterwards
     ( curl -sSLf https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - || echo 'return 1' ) | sh -s \
           imagick/imagick@9df92616f577e38625b96b7b903582a46c064739 && \
 #    pecl install imagick && \


### PR DESCRIPTION
Hi Jens, 
anbei die Anpassungen für den arm64-Build von PHP 8.3 Bei mir lokal funktioniert es dann.
Ich verwende dafür https://github.com/mlocati/docker-php-extension-installer. Dann erspart man sich das rumgehampel mit manuellem Klonen und Aufräumen. Ich hoffe, das ist okay.